### PR TITLE
Improve contrast in image expression layer

### DIFF
--- a/src/algorithms/imagery/index.js
+++ b/src/algorithms/imagery/index.js
@@ -91,7 +91,7 @@ export const cumulativeWindow = (fullHistogram, percentile) => {
       const min = ee.Algorithms.If(sum.gt(cumulativeCut), ctx.getNumber('min'), buckets.getNumber(idx))
       
       return ee.Dictionary({ min, sum })
-    }, { min: 0, sum: 0 })
+    }, { min: buckets.getNumber(0), sum: 0 })
     
     return ee.Dictionary(cumulativeMin).getNumber('min')
   }

--- a/src/algorithms/imagery/index.js
+++ b/src/algorithms/imagery/index.js
@@ -61,3 +61,44 @@ export const createThumbnail = (image, geometry, params, callback) => {
 
   return image.getThumbURL(generationParams, callback);
 }
+
+/**
+ * Calculates the cumulative window of the *fullHistogram*
+ * by removing up to *percentile* pixels in each side of
+ * the histogram's buckets.
+ * @param {ee.Dictionary} fullHistogram 
+ * @param {Number|ee.Number} percentile 
+ * @returns {ee.List} the cumulative window bounds (min/max)
+ */
+export const cumulativeWindow = (fullHistogram, percentile) => {
+  /* Cast to dictionary and retrieve histogram and buckets */
+  const cast = ee.Dictionary(fullHistogram)
+  const histogram = ee.List(cast.get('histogram'))
+  const buckets = ee.List(cast.get('bucketMeans'))
+  
+  const pixelCount = ee.Number(histogram.reduce(ee.Reducer.sum()))
+  const cumulativeCut = pixelCount.multiply(percentile)
+  
+  /*
+   * lowerBound returns the min level where cumulative sum
+   * would have exceeded the percentile threshold
+  */
+  const lowerBound = (histogram, buckets) => {
+    const cumulativeMin = ee.List.sequence(0, buckets.size().subtract(1)).iterate((idx, acc) => {
+      const ctx = ee.Dictionary(acc)
+      
+      const sum = ctx.getNumber('sum').add(histogram.getNumber(idx))
+      const min = ee.Algorithms.If(sum.gt(cumulativeCut), ctx.getNumber('min'), buckets.getNumber(idx))
+      
+      return ee.Dictionary({ min, sum })
+    }, { min: 0, sum: 0 })
+    
+    return ee.Dictionary(cumulativeMin).getNumber('min')
+  }
+  
+  /* Calculate the bound of each side */
+  const lower = lowerBound(histogram, buckets)
+  const upper = lowerBound(histogram.reverse(), buckets.reverse())
+  
+  return ee.List([lower, upper])
+}


### PR DESCRIPTION
CASSIE now adjusts the visualization parameters, according to the following proposal:

**Histogram equalization**:

_Inputs_:

1. histogram data (result of passing ee.Reducer.histogram to ee.Image.reduceRegion), i.e. an ee.Dictionary with keys _'histogram'_ and _'bucketMeans'_
2. removal percentile

_Behavior_:

Iterate histogram values (bucket occurrence count) in each side separately, returning the first bucket that would have caused the side's cumulative sum to exceed the given percentile. This way, we can ignore the offset levels in each side of the histogram and therefore improve the image contrast by applying the _returned minimum and maximum_ values.

_Output_:

An ee.List with 2 elements: the new minimum and maximum visualization values.

_Sample_ (image containing only the RED band):

![Grey level contrast sample](https://user-images.githubusercontent.com/32988572/111006350-6c800280-836b-11eb-9ce6-00c01eefd41b.jpg)

Refs: #47 