### PR TITLE
:bug: removeLayer button fix #56

### DIFF
--- a/src/app/components/map/ImageViewer.jsx
+++ b/src/app/components/map/ImageViewer.jsx
@@ -42,6 +42,7 @@ const ImageViewer = ({ image, index }) => {
     <Accordion defaultExpanded style={{ margin: "1px 1px" }}>
       <AccordionSummary expandIcon={<ExpandIcon />}>
         <Typography className={classes.title} variant="body1">
+          {console.log('img', image)}
           {
             // Get mission short name by splitting its name
             image.name.split('/')[0]+' - '+formatDate(image.date, true)

--- a/src/app/components/map/ImageViewer.jsx
+++ b/src/app/components/map/ImageViewer.jsx
@@ -42,10 +42,10 @@ const ImageViewer = ({ image, index }) => {
     <Accordion defaultExpanded style={{ margin: "1px 1px" }}>
       <AccordionSummary expandIcon={<ExpandIcon />}>
         <Typography className={classes.title} variant="body1">
-          {console.log('img', image)}
           {
             // Get mission short name by splitting its name
-            image.name.split('/')[0]+' - '+formatDate(image.date, true)
+            typeof(image) == 'object' ?
+            image.name.split('/')[0]+' - '+formatDate(image.date, true) : ''
           }
         </Typography>
       </AccordionSummary>

--- a/src/app/components/map/LayerActions.jsx
+++ b/src/app/components/map/LayerActions.jsx
@@ -58,7 +58,10 @@ const LayerActions = ({ layer, index, parent }) => {
 
         {removable && (
           <Tooltip title="Remover" placement="top">
-            <IconButton onClick={() => dispatch(imagery.removeLayer(index))}>
+            <IconButton onClick={() => {
+              console.log("layerAction-index "+index)
+              dispatch(imagery.removeLayer(index))
+            }}>
               <Delete />
             </IconButton>
           </Tooltip>

--- a/src/app/components/map/LayerActions.jsx
+++ b/src/app/components/map/LayerActions.jsx
@@ -58,7 +58,7 @@ const LayerActions = ({ layer, index, parent }) => {
 
         {removable && (
           <Tooltip title="Remover" placement="top">
-            <IconButton onClick={() => {} /* @TODO Fix layer removal */}>
+            <IconButton onClick={() => dispatch(imagery.removeLayer(index))}>
               <Delete />
             </IconButton>
           </Tooltip>

--- a/src/app/components/map/LayerActions.jsx
+++ b/src/app/components/map/LayerActions.jsx
@@ -59,7 +59,6 @@ const LayerActions = ({ layer, index, parent }) => {
         {removable && (
           <Tooltip title="Remover" placement="top">
             <IconButton onClick={() => {
-              console.log("layerAction-index "+index)
               dispatch(imagery.removeLayer(index))
             }}>
               <Delete />

--- a/src/common/map.js
+++ b/src/common/map.js
@@ -98,9 +98,6 @@ export const addLayer = (overlay, index) => {
 };
 
 export const removeLayer = (index) => {
-  console.log("layers")
-  console.log(Map.customLayers)
-  console.log("tentando remover camada em " + index)
   Map.customLayers.splice(index, 1);
   Map.overlayMapTypes.removeAt(index);
 };

--- a/src/common/map.js
+++ b/src/common/map.js
@@ -98,6 +98,9 @@ export const addLayer = (overlay, index) => {
 };
 
 export const removeLayer = (index) => {
+  console.log("layers")
+  console.log(Map.customLayers)
+  console.log("tentando remover camada em " + index)
   Map.customLayers.splice(index, 1);
   Map.overlayMapTypes.removeAt(index);
 };

--- a/src/common/map.js
+++ b/src/common/map.js
@@ -98,6 +98,7 @@ export const addLayer = (overlay, index) => {
 };
 
 export const removeLayer = (index) => {
+  console.log(` removendo later ${index} do mapa`)
   Map.customLayers.splice(index, 1);
   Map.overlayMapTypes.removeAt(index);
 };
@@ -170,7 +171,12 @@ export const clearOutline = () => {
 };
 
 export const setOpacity = (layer, value) => {
-  Map.customLayers[layer].setOpacity(value);
+  if (Map.customLayers[layer] !== undefined) {
+    Map.customLayers[layer].setOpacity(value);
+  } else {
+    console.warn(`Layer ${layer} is not defined`)
+  }
+
 };
 
 export const toLatLng = (coordinates) => {

--- a/src/common/map.js
+++ b/src/common/map.js
@@ -97,10 +97,17 @@ export const addLayer = (overlay, index) => {
   return index;
 };
 
+/** 
+ * Because of how customLayers works, each time one layer is deleted, 
+ * the others change the index and the reference ends up being lost.
+ * 
+ * So I ended up choosing to just remove the references to this layer in the interface 
+ * and make it transparent.
+**/
 export const removeLayer = (index) => {
-  console.log(` removendo later ${index} do mapa`)
-  Map.customLayers.splice(index, 1);
-  Map.overlayMapTypes.removeAt(index);
+  Map.customLayers[index].setOpacity(0);
+  // Map.customLayers.splice(index, 1);
+  // Map.overlayMapTypes.removeAt(index);
 };
 
 export const replaceLayer = (index, overlay) => {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -77,8 +77,10 @@ export function computeInsertionIndex(parent) {
 export function findLayerIndex(identifier) {
   return createPipe("map", (state) => {
     for (let i = 0; i < state.layers.length; i++) {
-      if (parseInt(identifier, 10) === state.layers[i]) {
-        return i;
+      if (state.layers[i] !== undefined) {
+        if (parseInt(identifier, 10) === state.layers[i]) {
+          return i;
+        }
       }
     }
 
@@ -88,10 +90,12 @@ export function findLayerIndex(identifier) {
 
 export function findLayerParent(identifier) {
   return createPipe("imagery", (state) => {
-    for (let i = 0; i < Object.keys(state.images).length; i++) {
-      for (const j of Object.keys(state.images[i].layers)) {
-        if (parseInt(identifier, 10) === parseInt(j, 10)) {
-          return i;
+    for (let i = 0; i < state.imageId; i++) {
+      if (state.images[i] !== undefined) {
+        for (const j of Object.keys(state.images[i].layers)) {
+          if (parseInt(identifier, 10) === parseInt(j, 10)) {
+            return i;
+          }
         }
       }
     }

--- a/src/store/ducks/imagery/header.js
+++ b/src/store/ducks/imagery/header.js
@@ -15,6 +15,7 @@ export const Types = duckify(namespace, store, [
   "COMMIT_CHANGE",
   "ANALYZE_COASTLINE",
   "REQUEST_EXPRESSION",
+  "REMOVE_ELEMENT"
 ]);
 
 export const Actions = {
@@ -72,6 +73,11 @@ export const Actions = {
   commitChange: (layer, data) => ({
     type: Types.COMMIT_CHANGE,
     payload: { layer, data },
+  }),
+
+  removeElement: (layer) => ({
+    type: Types.REMOVE_ELEMENT,
+    payload: { layer },
   }),
 };
 

--- a/src/store/ducks/imagery/header.js
+++ b/src/store/ducks/imagery/header.js
@@ -10,6 +10,7 @@ export const Types = duckify(namespace, store, [
   "SET_BASELINE",
   "TOGGLE_VISIBILITY",
   "UPDATE_OPACITY",
+  "REMOVE_LAYER",
   "GENERATE_TRANSECTS",
   "COMMIT_CHANGE",
   "ANALYZE_COASTLINE",
@@ -47,6 +48,11 @@ export const Actions = {
   updateOpacity: (identifier, opacity) => ({
     type: Types.UPDATE_OPACITY,
     payload: { identifier, opacity },
+  }),
+
+  removeLayer: (identifier) => ({
+    type: Types.REMOVE_LAYER,
+    payload: { identifier },
   }),
 
   generateTransects: (identifier) => ({

--- a/src/store/ducks/imagery/reducer.js
+++ b/src/store/ducks/imagery/reducer.js
@@ -22,11 +22,9 @@ const alterLayer = (state, parent, layer, data) => {
 
 // return { ...state, layers: state.images[parent].layers.filter(lay => lay !== layer ) }
 const removeLayer = (state, parent, layer) => {
-  const images = update(state.images, {
-    [parent]: {
-      layers: {
-        $unset: [layer]
-      }
+  const images = update(state.images[parent], {
+    layers: {
+      $unset: [layer]
     }
   })
   return { ...state, images }

--- a/src/store/ducks/imagery/reducer.js
+++ b/src/store/ducks/imagery/reducer.js
@@ -22,7 +22,6 @@ const alterLayer = (state, parent, layer, data) => {
 
 // return { ...state, layers: state.images[parent].layers.filter(lay => lay !== layer ) }
 const removeLayer = (state, parent, layer) => {
-  console.log('parent ', parent)
   if (Object.keys(state.images[parent].layers).length <= 1) {
     return update(state.images, {
       $unset: [parent]

--- a/src/store/ducks/imagery/reducer.js
+++ b/src/store/ducks/imagery/reducer.js
@@ -22,13 +22,21 @@ const alterLayer = (state, parent, layer, data) => {
 
 // return { ...state, layers: state.images[parent].layers.filter(lay => lay !== layer ) }
 const removeLayer = (state, parent, layer) => {
-  return update(state.images, {
-    [parent]: {
-      layers: {
-        $unset: [layer]
+  console.log('parent ', parent)
+  if (Object.keys(state.images[parent].layers).length <= 1) {
+    return update(state.images, {
+      $unset: [parent]
+    })
+  }else{
+    return update(state.images, {
+      [parent]: {
+        layers: {
+          $unset: [layer]
+        }
       }
-    }
-  })
+    })
+  }
+  
   // let layers = state.images[parent].layers;
   // return update(state.images[parent], Object.keys(layers).filter(lay => lay !== layer).reduce((acc, cur) => ({ ...acc, [cur]: layers[cur] }), {}));
 };

--- a/src/store/ducks/imagery/reducer.js
+++ b/src/store/ducks/imagery/reducer.js
@@ -22,12 +22,13 @@ const alterLayer = (state, parent, layer, data) => {
 
 // return { ...state, layers: state.images[parent].layers.filter(lay => lay !== layer ) }
 const removeLayer = (state, parent, layer) => {
-  const images = update(state.images[parent], {
-    layers: {
-      $unset: [layer]
+  return update(state.images, {
+    [parent]: {
+      layers: {
+        $unset: [layer]
+      }
     }
   })
-  return { ...state, images }
   // let layers = state.images[parent].layers;
   // return update(state.images[parent], Object.keys(layers).filter(lay => lay !== layer).reduce((acc, cur) => ({ ...acc, [cur]: layers[cur] }), {}));
 };
@@ -68,8 +69,6 @@ export const reducer = (state = INITIAL_STATE, action) => {
         parent,
         action.payload.layer
       );
-      console.log('remove_element in imagery reducer')
-      console.log(parent)
       return { ...state, images };
     }
 

--- a/src/store/ducks/imagery/reducer.js
+++ b/src/store/ducks/imagery/reducer.js
@@ -20,6 +20,20 @@ const alterLayer = (state, parent, layer, data) => {
   });
 };
 
+// return { ...state, layers: state.images[parent].layers.filter(lay => lay !== layer ) }
+const removeLayer = (state, parent, layer) => {
+  const images = update(state.images, {
+    [parent]: {
+      layers: {
+        $unset: [layer]
+      }
+    }
+  })
+  return { ...state, images }
+  // let layers = state.images[parent].layers;
+  // return update(state.images[parent], Object.keys(layers).filter(lay => lay !== layer).reduce((acc, cur) => ({ ...acc, [cur]: layers[cur] }), {}));
+};
+
 export const reducer = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case Types.PUSH_IMAGE: {
@@ -45,6 +59,20 @@ export const reducer = (state = INITIAL_STATE, action) => {
       });
 
       return { ...state, images, layerId: state.layerId + 1 };
+    }
+    case Types.REMOVE_ELEMENT: {
+      const parent = Selectors.findLayerParent(action.payload.layer)(
+        state,
+        true
+      );
+      const images = removeLayer(
+        state,
+        parent,
+        action.payload.layer
+      );
+      console.log('remove_element in imagery reducer')
+      console.log(parent)
+      return { ...state, images };
     }
 
     case Types.COMMIT_CHANGE: {

--- a/src/store/ducks/imagery/saga/index.js
+++ b/src/store/ducks/imagery/saga/index.js
@@ -8,6 +8,7 @@ const root = function* () {
     takeLeading(Types.LOAD_LAYER, Layers.handleLoadLayer),
     takeEvery(Types.TOGGLE_VISIBILITY, Layers.handleToggleVisibility),
     takeEvery(Types.UPDATE_OPACITY, Layers.handleUpdateOpacity),
+    takeEvery(Types.REMOVE_LAYER, Layers.handleRemoveLayer),
     takeLeading(Types.REQUEST_EXPRESSION, Layers.handleRequestExpression),
     takeLeading(Types.ANALYZE_COASTLINE, Shoreline.handleAnalyzeCoastline),
   ]);

--- a/src/store/ducks/imagery/saga/layers.js
+++ b/src/store/ducks/imagery/saga/layers.js
@@ -55,6 +55,7 @@ export const handleUpdateOpacity = function* ({
   yield put(Imagery.Actions.commitChange(identifier, { opacity }));
 };
 
+
 export const handleRemoveLayer = function* ({
   payload: { identifier },
 }) {

--- a/src/store/ducks/imagery/saga/layers.js
+++ b/src/store/ducks/imagery/saga/layers.js
@@ -59,6 +59,7 @@ export const handleRemoveLayer = function* ({
   payload: { identifier },
 }) {
   yield put(Map.removeLayer(identifier));
+  yield put(Imagery.Actions.removeElement(identifier));
 };
 
 export const handleRequestExpression = function* ({ payload: { parent } }) {

--- a/src/store/ducks/imagery/saga/layers.js
+++ b/src/store/ducks/imagery/saga/layers.js
@@ -55,6 +55,12 @@ export const handleUpdateOpacity = function* ({
   yield put(Imagery.Actions.commitChange(identifier, { opacity }));
 };
 
+export const handleRemoveLayer = function* ({
+  payload: { identifier},
+}) {
+  yield put(Map.removeLayer(identifier));
+};
+
 export const handleRequestExpression = function* ({ payload: { parent } }) {
   const { name, expression } = yield call(openAndWait, "newLayer");
 

--- a/src/store/ducks/imagery/saga/layers.js
+++ b/src/store/ducks/imagery/saga/layers.js
@@ -56,7 +56,7 @@ export const handleUpdateOpacity = function* ({
 };
 
 export const handleRemoveLayer = function* ({
-  payload: { identifier},
+  payload: { identifier },
 }) {
   yield put(Map.removeLayer(identifier));
 };

--- a/src/store/ducks/map/header.js
+++ b/src/store/ducks/map/header.js
@@ -64,9 +64,9 @@ export const Actions = {
     type: Types.COMMIT_SHAPE_REMOVAL,
     payload: { index },
   }),
-  removeLayer: (index) => ({
+  removeLayer: (identifier) => ({
     type: Types.REMOVE_LAYER,
-    payload: { index },
+    payload: { identifier },
   }),
   removeShape: (index) => ({
     type: Types.REMOVE_SHAPE,

--- a/src/store/ducks/map/header.js
+++ b/src/store/ducks/map/header.js
@@ -6,6 +6,7 @@ export const store = "map";
 export const Types = duckify(namespace, store, [
   "ADD_EE_LAYER",
   "ADD_EE_FEATURE",
+  "REMOVE_LAYER",
   "REMOVE_SHAPE",
   "REMOVE_SHAPE_GROUP",
   "CHANGE_OPACITY",
@@ -61,6 +62,10 @@ export const Actions = {
   }),
   commitShapeRemoval: (index) => ({
     type: Types.COMMIT_SHAPE_REMOVAL,
+    payload: { index },
+  }),
+  removeLayer: (index) => ({
+    type: Types.REMOVE_LAYER,
     payload: { index },
   }),
   removeShape: (index) => ({

--- a/src/store/ducks/map/saga.js
+++ b/src/store/ducks/map/saga.js
@@ -89,8 +89,6 @@ const handleChangeOpacity = function* ({ payload: { identifier, opacity } }) {
 };
 
 const handleRemoveLayer = function* ({ payload: { identifier } }) {
-  console.log('map saga handle remove identifier')
-  console.log(identifier)
   const index = yield select(findLayerIndex(identifier));
   Map.removeLayer(index)
 };

--- a/src/store/ducks/map/saga.js
+++ b/src/store/ducks/map/saga.js
@@ -84,7 +84,6 @@ const handleAddEEFeature = function* ({
 
 const handleChangeOpacity = function* ({ payload: { identifier, opacity } }) {
   const index = yield select(findLayerIndex(identifier));
-
   Map.setOpacity(index, opacity);
 };
 

--- a/src/store/ducks/map/saga.js
+++ b/src/store/ducks/map/saga.js
@@ -88,6 +88,14 @@ const handleChangeOpacity = function* ({ payload: { identifier, opacity } }) {
   Map.setOpacity(index, opacity);
 };
 
+const handleRemoveLayer = function* ({ payload: { identifier } }) {
+  console.log('map saga handle remove identifier')
+  console.log(identifier)
+  const index = yield select(findLayerIndex(identifier));
+  Map.removeLayer(index)
+};
+
+
 // eslint-disable-next-line require-yield
 const handleRequestDrawing = function* ({ payload: { drawingType } }) {
   Map.setDrawingControlsVisible(false);
@@ -158,6 +166,7 @@ const root = function* () {
     bufferedHandler(Types.CLEAR_HIGHLIGHT, handleClearHighlight),
     concurrentHandler(Types.REMOVE_SHAPE_GROUP, handleRemoveShapeGroup),
     bufferedHandler(Types.REMOVE_SHAPE, handleRemoveShape),
+    bufferedHandler(Types.REMOVE_LAYER, handleRemoveLayer),
     bufferedHandler(Types.CENTRALIZE_MAP, handleCentralizeMap),
   ]);
 };


### PR DESCRIPTION
Because of how customLayers works, each time one layer is deleted, the others change the index and the reference ends up being lost.

So I ended up choosing to just remove the references to this layer in the interface and make it transparent.